### PR TITLE
feat: make contact us form accessible ✨

### DIFF
--- a/additionalpage/contact.html
+++ b/additionalpage/contact.html
@@ -109,10 +109,12 @@
            <div class="contact-form" role="form">
                <div class="name-email-div">
                    <div class="inputDiv">
+                    <label for="name">Enter your Full Name: </label>
                     <input type="text" name="name" id="name" placeholder="Enter Full Name "  onkeyup="handleChange(event)" aria-required="true" aria-describedby="nameError" aria-label="Full Name">
                     <p id="nameError" class="error hidden" role="alert">Name should be of atleast 6 characters</p>
                    </div>
                     <div class="inputDiv">
+                        <label for="email">Enter your Email: </label>
                         <input type="email" name="email" id="email" placeholder="Enter Email" onkeyup="handleChange(event)" aria-required="true" aria-describedby="emailError" aria-label="Email">
                     <p class="error hidden" id="emailError" role="alert">Enter Valid Email</p>
                     </div>
@@ -120,18 +122,20 @@
                </div>
                <!-- <input type="text" name="number" id="number" placeholder="Enter Phone Number"> -->
                <div >
+                <label for="subject">Enter your Mail Subject: </label>
                 <input type="text" name="subject" id="subject" placeholder="Enter Mail Subject" onkeyup="handleChange(event)" aria-required="true" aria-describedby="subjectError" aria-label="Subject">
                 <p id="subjectError" class="error hidden" role="alert">Mail Subject must be within 2 to 6 words</p>
                </div>
              <div >
+                <label for="message">Enter your Message: </label>
                 <input type="text" name="message" id="message" placeholder="Enter Message" class="message" onkeyup="handleChange(event)" aria-required="true" aria-describedby="messageError" aria-label="Message">
                 <p id="messageError" class="error hidden" role="alert">Message must be of within 10 to 100 words</p>
              </div>
-               
-               <a href="#"><div class="btn" onclick="handleSubmitClick()" role="button" aria-pressed="false">
+               <a href="#">
+                <div class="btn" onclick="handleSubmitClick()" role="button" aria-pressed="false">
                    Send Message
-                   </div></a>
-                   
+                </div>
+               </a>
            </div>
        </div>
         </div>

--- a/additionalpage/contact.html
+++ b/additionalpage/contact.html
@@ -109,12 +109,12 @@
            <div class="contact-form" role="form">
                <div class="name-email-div">
                    <div class="inputDiv">
-                    <label for="name">Enter your Full Name: </label>
+                    <label for="name" class="sr-only-label">Enter your Full Name: </label>
                     <input type="text" name="name" id="name" placeholder="Enter Full Name "  onkeyup="handleChange(event)" aria-required="true" aria-describedby="nameError" aria-label="Full Name">
                     <p id="nameError" class="error hidden" role="alert">Name should be of atleast 6 characters</p>
                    </div>
                     <div class="inputDiv">
-                        <label for="email">Enter your Email: </label>
+                        <label for="email" class="sr-only-label">Enter your Email: </label>
                         <input type="email" name="email" id="email" placeholder="Enter Email" onkeyup="handleChange(event)" aria-required="true" aria-describedby="emailError" aria-label="Email">
                     <p class="error hidden" id="emailError" role="alert">Enter Valid Email</p>
                     </div>
@@ -122,12 +122,12 @@
                </div>
                <!-- <input type="text" name="number" id="number" placeholder="Enter Phone Number"> -->
                <div >
-                <label for="subject">Enter your Mail Subject: </label>
+                <label for="subject" class="sr-only-label">Enter your Mail Subject: </label>
                 <input type="text" name="subject" id="subject" placeholder="Enter Mail Subject" onkeyup="handleChange(event)" aria-required="true" aria-describedby="subjectError" aria-label="Subject">
                 <p id="subjectError" class="error hidden" role="alert">Mail Subject must be within 2 to 6 words</p>
                </div>
              <div >
-                <label for="message">Enter your Message: </label>
+                <label for="message" class="sr-only-label">Enter your Message: </label>
                 <input type="text" name="message" id="message" placeholder="Enter Message" class="message" onkeyup="handleChange(event)" aria-required="true" aria-describedby="messageError" aria-label="Message">
                 <p id="messageError" class="error hidden" role="alert">Message must be of within 10 to 100 words</p>
              </div>

--- a/dist/contact.css
+++ b/dist/contact.css
@@ -87,6 +87,17 @@
     width: 170px;
 }
 
+.sr-only-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
 .contact-form{
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Related Issue

Closes #802 

## Description
- Added `label` for every `input` elements on Contact Us form.
- Every `label` is properly linked to their corresponding `input` element by utilizing the `for` and `id` attributes.
- The `label` elements can't be seen via the user because they are all hidden by utilizing `sr-only` class, where the screen readers only know them.
- So our contact us form is much more accessible than before and ensures the accessibility principles.

## Screenshot Section
- We can't take screenshots of accessibility changes rather than code changes, Accessibility changes are often invisible to the user because it's intended to guide disabled people