### PR TITLE
Image Link Bug Removed

### DIFF
--- a/additionalpage/game.html
+++ b/additionalpage/game.html
@@ -1840,7 +1840,7 @@
                 <!-- -------------- -->
                 <div class="game-card">
                     <div class="game-card-top img-fit-cover">
-                        <img src="../SinglePlayer - Games/Banner - image/Magic_Tiles.jpg" alt="">
+                        <img src="https://user-images.githubusercontent.com/115471178/246663502-8dfad6cb-a21b-4f37-b5de-19b3c3badee4.jpg" alt="">
                         <div class="ratings-count">
                             241
                             <img src="../assets/icons/star-black.svg" alt="" class="ms-2">
@@ -2950,7 +2950,7 @@
                 <div class = "game-card">
                     <div class = "game-card-top img-fit-cover">
                      <video src="https://drive.google.com/file/d/1Yc30XSZnuAWSUfJoujcs_Z2J-2MITZww/view" link " type="video/mp4" muted loop class="clip"  ></video>
-                        <img src = "../SinglePlayer - Games/Banner - images/Ball_Jumper_Game.jpeg" alt = "">
+                        <img src = "https://user-images.githubusercontent.com/114821855/256990451-4f77dda0-f30a-4433-9b41-7075daa893f6.jpeg" alt = "">
                         <div class = "ratings-count">
                             45
                             <img src = "../SinglePlayer - Games/Banner - images/Ball_Jumper_Game.jpeg" alt = "" class = "ms-2">
@@ -5972,7 +5972,7 @@
                     <video src="https://drive.google.com/uc?id=13_0rHCiE1D96TtLFodRBUEX6BdBDMvAr" type="video/mp4" muted
                         loop class="clip"></video>
                     <div class="game-card-top display-none img-fit-cover">
-                        <img src="../SinglePlayer - Games/whack-a-mole/Hover_Board_Effect.png" alt="img">
+                        <img src="https://user-images.githubusercontent.com/95160083/246581032-fd880d56-8734-494c-b297-90a1895021a9.png" alt="img">
                         <div class="ratings-count">
                             41
                             <img src="../assets/icons/star-black.svg" alt="" class="ms-2">
@@ -7337,7 +7337,7 @@
                         <video
                             src="https://github.com/avi-tech-test/git-branching-prac/assets/129321548/a5b25e93-b5c1-4b29-9540-3f7524228318"
                             link " type=" video/mp4" muted loop class="clip"></video>
-                        <img src="../SinglePlayer - Games/Banner - image/FallingBlocks.jpg" alt="">
+                        <img src="https://user-images.githubusercontent.com/80768852/258645667-33ea5e3c-4c5a-441f-99c7-1a4e6cb7929b.png" alt="">
                         <div class="ratings-count">
                             45
                             <img src="../assets/icons/star-black.svg" alt="" class="ms-2">
@@ -7674,7 +7674,7 @@
                 <!-- ------------- -->
                 <div class="game-card">
                     <div class="game-card-top img-fit-cover">
-                        <img src="../SinglePlayer - Games/Banner - images/cast_and_catch.png" alt="">
+                        <img src="https://user-images.githubusercontent.com/111994644/248537411-52d47b73-57f7-4080-a929-b4158d4e56d3.png" alt="">
                         <div class="ratings-count">
                             45
                             <img src="../assets/icons/star-black.svg" alt="" class="ms-2">
@@ -7892,7 +7892,7 @@
                     <div class="game-card-top img-fit-cover">
                         <video src="https://drive.google.com/file/d/16JRpBQh2hO98Om4sgm-Q8JILYO03cipW/view?usp=sharing"
                             link " type=" video/mp4" muted loop class="clip"></video>
-                        <img src="../SinglePlayer - Games/Banner - image/Rabbit_And_Fox_Game.gif" alt="">
+                        <img src="https://user-images.githubusercontent.com/114821855/249302457-be4b992e-577d-4c98-95a1-79b4388b5025.gif" alt="">
                         <div class="ratings-count">
                             45
                             <img src="../SinglePlayer - Games/Banner - image/Rabbit_And_Fox_Game.gif" alt=""
@@ -8005,7 +8005,7 @@
                 <!-- 3d Snake Game -->
                 <div class="game-card">
                     <div class="game-card-top img-fit-cover">
-                        <img src="/assets/images/Screenshot_2020-07-19 Facebook.jpg" alt="">
+                        <img src="https://user-images.githubusercontent.com/121503426/249248123-fe03b921-8b81-4040-9afc-b8e6041cf285.jpg" alt="">
                         <div class="ratings-count">
                             999
                             <img src="../assets/icons/star-black.svg" alt="" class="ms-2">
@@ -8132,7 +8132,7 @@
                     <div class="game-card-top img-fit-cover">
                         <video src="https://drive.google.com/file/d/1lmKAyNjtGaFUbC7hOTqnfyF917cK_Nue/view?usp=sharing"
                             link " type=" video/mp4" muted loop class="clip"></video>
-                        <img src="../SinglePlayer - Games/Banner - images/simon-says.png" alt="">
+                        <img src="https://user-images.githubusercontent.com/119125519/249194657-4f5fff1e-5826-4fdf-bb8a-a380235cd9e1.png" alt="">
                         <div class="ratings-count">
                             45
                             <img src="../assets/icons/star-black.svg" alt="" class="ms-2">
@@ -8242,7 +8242,7 @@
                     <div class="game-card-top img-fit-cover">
                         <video src="https://drive.google.com/file/d/1lmKAyNjtGaFUbC7hOTqnfyF917cK_Nue/view?usp=sharing"
                             link " type=" video/mp4" muted loop class="clip"></video>
-                        <img src="../SinglePlayer - Games/Banner - images/simon-says.png" alt="">
+                        <img src="https://user-images.githubusercontent.com/95160083/250291740-5f58a4a7-3b29-4de9-832c-7422e1674e5b.png" alt="">
                         <div class="ratings-count">
                             45
                             <img src="../assets/icons/star-black.svg" alt="" class="ms-2">
@@ -8358,7 +8358,7 @@
                 <div class = "game-card">
                     <div class = "game-card-top img-fit-cover">
                      <video src="https://drive.google.com/file/d/1kUuSptNUkIETH0IVM93r11sJOuXAkorY/view?usp=sharing" link " type="video/mp4" muted loop class="clip"  ></video>
-                        <img src = "../SinglePlayer - Games/Banner - images/Animal_Name_Guessing_Game.png" alt = "">
+                        <img src = "https://user-images.githubusercontent.com/114821855/254148173-fb896003-9cae-408a-81e2-dae33b62fc4d.png" alt = "">
                         <div class = "ratings-count">
                             45
                             <img src = "../SinglePlayer - Games/Banner - images/Animal_Name_Guessing_Game.png" alt = "" class = "ms-2">
@@ -8412,7 +8412,7 @@
                 <div class = "game-card">
                     <div class = "game-card-top img-fit-cover">
                      <video src="https://drive.google.com/file/d/1rUIMih13uxEn1qRAJ93Zw8WUAeg-294i/view?usp=sharing" link " type="video/mp4" muted loop class="clip"  ></video>
-                        <img src = "../SinglePlayer - Games/Banner - images/Basketball Game.png" alt = "">
+                        <img src = "https://user-images.githubusercontent.com/111994644/250331052-b53d9524-a062-49d8-9ba7-676327300930.png" alt = "">
                         <div class = "ratings-count">
                             45
                             <img src = "../SinglePlayer - Games/Banner - images/Basketball Game.png" alt = "" class = "ms-2">
@@ -8470,7 +8470,7 @@
                     <div class="game-card-top img-fit-cover">
                         <video src="https://drive.google.com/file/d/1cVdtD-jYdrQKtjrk80UaxDr92MMh3wfN/view?usp=sharing"
                             link " type=" video/mp4" muted loop class="clip"></video>
-                        <img src="../SinglePlayer - Games/Banner - images/Shadow_Poke_Guessing_Game.png" alt="">
+                        <img src="https://user-images.githubusercontent.com/114821855/253790511-7022c80e-acbb-42d8-82c0-a014094a049a.png" alt="">
                         <div class="ratings-count">
                             45
                             <img src="../SinglePlayer - Games/Banner - images/Shadow_Poke_Guessing_Game.png" alt=""
@@ -8529,7 +8529,7 @@
                     <div class="game-card-top img-fit-cover">
                         <video src="https://drive.google.com/file/d/1xh9IgK4SDjiCwHRU4fyCAQi2iSKL1NCI/view?usp=sharing"
                             link " type=" video/mp4" muted loop class="clip"></video>
-                        <img src="../SinglePlayer - Games/Banner - images/Chinese_Checkers.png" alt="">
+                        <img src="https://user-images.githubusercontent.com/114821855/252801786-d1d84255-2a06-48f1-a7f5-1173a1cc33e5.png" alt="">
                         <div class="ratings-count">
                             45
                             <img src="../SinglePlayer - Games/Banner - images/Chinese_Checkers.png" alt="" class="ms-2">
@@ -8587,6 +8587,7 @@
                     <div class="game-card-top img-fit-cover">
                         <video src="https://drive.google.com/file/d/1sqgigdYRSGsaKiZrD4H1T5doDj9hXfhq/view?usp=sharing"
                             link " type=" video/mp4" muted loop class="clip"></video>
+                            <img src = "https://user-images.githubusercontent.com/114821855/252324012-45926c39-bac5-4fb9-82e1-85d48105fc7a.gif" alt = "">
 
                         <div class="ratings-count">
                             45
@@ -8643,7 +8644,7 @@
                 <div class = "game-card">
                     <div class = "game-card-top img-fit-cover">
                      <video src="https://drive.google.com/file/d/1scIBtyjKd82SuQNNLDnXaeDIyOD-th5v/view?usp=sharing" link " type="video/mp4" muted loop class="clip"  ></video>
-                        <img src = "../SinglePlayer - Games/Banner - images/Math_Sprint_Game.png" alt = "">
+                        <img src = "https://user-images.githubusercontent.com/114821855/256421270-088cacd6-dc8c-4472-9394-c9812615c941.png" alt = "">
                         <div class = "ratings-count">
                             45
                             <img src = "../SinglePlayer - Games/Banner - images/Math_Sprint_Game.png" alt = "" class = "ms-2">
@@ -8703,7 +8704,7 @@
                 <div class = "game-card">
                     <div class = "game-card-top img-fit-cover">
                      <video src="https://drive.google.com/file/d/1a5IKLxwWE4NIOXZ51KmzJNgq9oAKDOGX/view?usp=sharing" link " type="video/mp4" muted loop class="clip"  ></video>
-                        <img src = "../SinglePlayer - Games/Banner - images/Marvel_Role_Playing_Game.png" alt = "">
+                        <img src = "https://user-images.githubusercontent.com/114821855/255301784-23814b00-b7ef-4b7a-91df-bd202f862a0b.png" alt = "">
                         <div class = "ratings-count">
                             45
                             <img src = "../SinglePlayer - Games/Banner - images/Marvel_Role_Playing_Game.png" alt = "" class = "ms-2">


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue*

Closes #876 

## Description

I have added proper Image links to the codebase. And now we can see the preview for every game.

## Screenshot Section

![image](https://github.com/GameSphere-MultiPlayer/GameSphere/assets/80768852/254380bf-d1ce-4eb6-b595-5f1a0b2a3cc8)

## 

Demo Video Section*

https://github.com/GameSphere-MultiPlayer/GameSphere/assets/80768852/78505d3b-9a7c-4385-bf86-453a31fdd203

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] I have added an image into screen sort in "SinglePlayer - Games/Banner - image" in this section*
